### PR TITLE
Don't log the time field if it is zero

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -69,8 +69,10 @@ func (e encoder) writeColoredDuration(w *buffer, d time.Duration, c ANSIMod) {
 }
 
 func (e encoder) writeTimestamp(buf *buffer, tt time.Time) {
-	e.writeColoredTime(buf, tt, e.opts.TimeFormat, e.opts.Theme.Timestamp())
-	buf.AppendByte(' ')
+	if !tt.IsZero() {
+		e.writeColoredTime(buf, tt, e.opts.TimeFormat, e.opts.Theme.Timestamp())
+		buf.AppendByte(' ')
+	}
 }
 
 func (e encoder) writeSource(buf *buffer, pc uintptr, cwd string) {

--- a/handler_test.go
+++ b/handler_test.go
@@ -26,6 +26,19 @@ func TestHandler_TimeFormat(t *testing.T) {
 	AssertEqual(t, expected, buf.String())
 }
 
+// Handlers should not log the time field if it is zero.
+// '- If r.Time is the zero time, ignore the time.'
+// https://pkg.go.dev/log/slog@master#Handler
+func TestHandler_TimeZero(t *testing.T) {
+	buf := bytes.Buffer{}
+	h := NewHandler(&buf, &HandlerOptions{TimeFormat: time.RFC3339Nano, NoColor: true})
+	rec := slog.NewRecord(time.Time{}, slog.LevelInfo, "foobar", 0)
+	AssertNoError(t, h.Handle(context.Background(), rec))
+
+	expected := fmt.Sprintf("INF foobar\n")
+	AssertEqual(t, expected, buf.String())
+}
+
 func TestHandler_NoColor(t *testing.T) {
 	buf := bytes.Buffer{}
 	h := NewHandler(&buf, &HandlerOptions{NoColor: true})


### PR DESCRIPTION
  Handlers should not log the basic `time` field if it is zero.  
  :point_right: ['- If r.Time is the zero time, ignore the time.'](https://pkg.go.dev/log/slog@master#Handler)

Not sure if this can ever happen but it is documented so here's a fix.