### PR TITLE
Use fmt for errors, like slog.TextHandler

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -45,6 +45,11 @@ func (b *buffer) WriteTo(dst io.Writer) (int64, error) {
 	return int64(n), nil
 }
 
+func (b *buffer) Write(bt []byte) (int, error) {
+	*b = append(*b, bt...)
+	return len(bt), nil
+}
+
 func (b *buffer) Reset() {
 	*b = (*b)[:0]
 }

--- a/encoding.go
+++ b/encoding.go
@@ -144,9 +144,13 @@ func (e encoder) writeValue(buf *buffer, value slog.Value) {
 	case slog.KindAny:
 		switch v := value.Any().(type) {
 		case error:
-			e.withColor(buf, e.opts.Theme.AttrValueError(), func() {
-				fmt.Fprintf(buf, "%+v", v)
-			})
+			if _, ok := v.(fmt.Formatter); ok {
+				e.withColor(buf, e.opts.Theme.AttrValueError(), func() {
+					fmt.Fprintf(buf, "%+v", v)
+				})
+			} else {
+				e.writeColoredString(buf, v.Error(), e.opts.Theme.AttrValueError())
+			}
 			return
 		case fmt.Stringer:
 			e.writeColoredString(buf, v.String(), attrValue)

--- a/encoding.go
+++ b/encoding.go
@@ -144,7 +144,9 @@ func (e encoder) writeValue(buf *buffer, value slog.Value) {
 	case slog.KindAny:
 		switch v := value.Any().(type) {
 		case error:
-			e.writeColoredString(buf, v.Error(), e.opts.Theme.AttrValueError())
+			e.withColor(buf, e.opts.Theme.AttrValueError(), func() {
+				fmt.Fprintf(buf, "%+v", v)
+			})
 			return
 		case fmt.Stringer:
 			e.writeColoredString(buf, v.String(), attrValue)

--- a/handler_test.go
+++ b/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -72,6 +73,17 @@ func (v *theValuer) LogValue() slog.Value {
 	return slog.StringValue(fmt.Sprintf("The word is '%s'", v.word))
 }
 
+type formatterError struct {
+	error
+}
+
+func (e *formatterError) Format(f fmt.State, verb rune) {
+	if verb == 'v' && f.Flag('+') {
+		io.WriteString(f, "formatted ")
+	}
+	io.WriteString(f, e.Error())
+}
+
 func TestHandler_Attr(t *testing.T) {
 	buf := bytes.Buffer{}
 	h := NewHandler(&buf, &HandlerOptions{NoColor: true})
@@ -87,6 +99,7 @@ func TestHandler_Attr(t *testing.T) {
 		slog.Duration("dur", time.Second),
 		slog.Group("group", slog.String("foo", "bar"), slog.Group("subgroup", slog.String("foo", "bar"))),
 		slog.Any("err", errors.New("the error")),
+		slog.Any("formattedError", &formatterError{errors.New("the error")}),
 		slog.Any("stringer", theStringer{}),
 		slog.Any("nostringer", noStringer{Foo: "bar"}),
 		// Resolve LogValuer items in addition to Stringer items.
@@ -102,7 +115,7 @@ func TestHandler_Attr(t *testing.T) {
 	)
 	AssertNoError(t, h.Handle(context.Background(), rec))
 
-	expected := fmt.Sprintf("%s INF foobar bool=true int=-12 uint=12 float=3.14 foo=bar time=%s dur=1s group.foo=bar group.subgroup.foo=bar err=the error stringer=stringer nostringer={bar} valuer=The word is 'distant'\n", now.Format(time.DateTime), now.Format(time.DateTime))
+	expected := fmt.Sprintf("%s INF foobar bool=true int=-12 uint=12 float=3.14 foo=bar time=%s dur=1s group.foo=bar group.subgroup.foo=bar err=the error formattedError=formatted the error stringer=stringer nostringer={bar} valuer=The word is 'distant'\n", now.Format(time.DateTime), now.Format(time.DateTime))
 	AssertEqual(t, expected, buf.String())
 }
 


### PR DESCRIPTION
Uses fmt.Fprintf with "%+v" to print errors.  Useful with some error packages which render additional information like stacktraces.  Addresses #7