### PR TITLE
Multiline support

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -36,6 +36,7 @@ var attrs = []slog.Attr{
 	slog.Any("err", errors.New("yo")),
 	slog.Group("empty"),
 	slog.Group("group", slog.String("bar", "baz")),
+	slog.String("multi", "foo\nbar"),
 }
 
 var attrsAny = func() (a []any) {

--- a/buffer.go
+++ b/buffer.go
@@ -30,6 +30,10 @@ func (b *buffer) Cap() int {
 }
 
 func (b *buffer) WriteTo(dst io.Writer) (int64, error) {
+	if b == nil {
+		// for convenience, if receiver is nil, treat it like an empty buffer
+		return 0, nil
+	}
 	l := len(*b)
 	if l == 0 {
 		return 0, nil

--- a/buffer_test.go
+++ b/buffer_test.go
@@ -46,6 +46,15 @@ func TestBuffer_WriteTo(t *testing.T) {
 	AssertNoError(t, err)
 	AssertEqual(t, "foobar", dest.String())
 	AssertZero(t, b.Len())
+
+	t.Run("nilbuffer", func(t *testing.T) {
+		// if receiver is nil, do nothing
+		dest.Reset()
+		c, err := (*buffer)(nil).WriteTo(&dest)
+		AssertNoError(t, err)
+		AssertZero(t, c)
+		AssertZero(t, dest.Len())
+	})
 }
 
 func TestBuffer_Clone(t *testing.T) {

--- a/encoding.go
+++ b/encoding.go
@@ -114,6 +114,7 @@ func (e encoder) writeAttr(buf *buffer, a slog.Attr, group string) {
 		}
 		return
 	}
+
 	buf.AppendByte(' ')
 	e.withColor(buf, e.opts.Theme.AttrKey(), func() {
 		if group != "" {

--- a/handler_test.go
+++ b/handler_test.go
@@ -106,6 +106,73 @@ func TestHandler_Attr(t *testing.T) {
 	AssertEqual(t, expected, buf.String())
 }
 
+func TestHandler_AttrsWithNewlines(t *testing.T) {
+	tests := []struct {
+		name           string
+		msg            string
+		escapeNewlines bool
+		attrs          []slog.Attr
+		want           string
+	}{
+		{
+			name: "single attr",
+			attrs: []slog.Attr{
+				slog.String("foo", "line one\nline two"),
+			},
+			want: "INF multiline attrs foo=\nline one\nline two\n",
+		},
+		{
+			name: "multiple attrs",
+			attrs: []slog.Attr{
+				slog.String("foo", "line one\nline two"),
+				slog.String("bar", "line three\nline four"),
+			},
+			want: "INF multiline attrs foo=\nline one\nline two\nbar=\nline three\nline four\n",
+		},
+		{
+			name: "sort multiline attrs to end",
+			attrs: []slog.Attr{
+				slog.String("size", "big"),
+				slog.String("foo", "line one\nline two"),
+				slog.String("weight", "heavy"),
+				slog.String("bar", "line three\nline four"),
+				slog.String("color", "red"),
+			},
+			want: "INF multiline attrs size=big weight=heavy color=red foo=\nline one\nline two\nbar=\nline three\nline four\n",
+		},
+		{
+			name: "multiline message",
+			msg:  "multiline\nmessage",
+			want: "INF multiline\nmessage\n",
+		},
+		{
+			name: "preserve leading and trailing newlines",
+			attrs: []slog.Attr{
+				slog.String("foo", "\nline one\nline two\n"),
+			},
+			want: "INF multiline attrs foo=\n\nline one\nline two\n\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			buf := bytes.Buffer{}
+			h := NewHandler(&buf, &HandlerOptions{NoColor: true})
+
+			msg := test.msg
+			if msg == "" {
+				msg = "multiline attrs"
+			}
+			rec := slog.NewRecord(time.Time{}, slog.LevelInfo, msg, 0)
+			rec.AddAttrs(test.attrs...)
+			AssertNoError(t, h.Handle(context.Background(), rec))
+
+			AssertEqual(t, test.want, buf.String())
+		})
+
+	}
+}
+
 // Handlers should not log groups (or subgroups) without fields.
 // '- If a group has no Attrs (even if it has a non-empty key), ignore it.'
 // https://pkg.go.dev/log/slog@master#Handler


### PR DESCRIPTION
Sort multiline attr values to the end, and add newlines to the beginning and end of the value, so the value is printed completely on its own lines, e.g. :

```
2025-01-09 16:12:48 INF main.go:215 > hello world logger=console-slog error=boom size=5 errorVerbose=
boom

main.testVariousHandlers
        /Users/regan/dev/flume/v2/cmd/demo/main.go:215
main.main
        /Users/regan/dev/flume/v2/cmd/demo/main.go:78
runtime.main
        /opt/homebrew/Cellar/go/1.23.4/libexec/src/runtime/proc.go:272
runtime.goexit
        /opt/homebrew/Cellar/go/1.23.4/libexec/src/runtime/asm_arm64.s:1223
2025-01-09 16:12:48 INF main.go:216 > hello world logger=console-slog error=boom size=5 flavor=vanilla
```