### PR TITLE
Headers, error formatting, multiline attr value handling, dim theme, and ReplaceAttr support

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -22,7 +22,9 @@ var handlers = []struct {
 }{
 	{"dummy", &DummyHandler{}},
 	{"console", NewHandler(io.Discard, &HandlerOptions{Level: slog.LevelDebug, AddSource: false})},
+	// {"console-replaceattr", NewHandler(io.Discard, &HandlerOptions{Level: slog.LevelDebug, AddSource: false, ReplaceAttr: func(_ []string, a slog.Attr) slog.Attr { return a }})},
 	{"std-text", slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false})},
+	// {"std-text-replaceattr", slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false, ReplaceAttr: func(_ []string, a slog.Attr) slog.Attr { return a }})},
 	{"std-json", slog.NewJSONHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false})},
 }
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -22,7 +22,9 @@ var handlers = []struct {
 }{
 	{"dummy", &DummyHandler{}},
 	{"console", NewHandler(io.Discard, &HandlerOptions{Level: slog.LevelDebug, AddSource: false})},
+	// {"console-headers", NewHandler(io.Discard, &HandlerOptions{Headers: []string{"foo"}, Level: slog.LevelDebug, AddSource: false})},
 	// {"console-replaceattr", NewHandler(io.Discard, &HandlerOptions{Level: slog.LevelDebug, AddSource: false, ReplaceAttr: func(_ []string, a slog.Attr) slog.Attr { return a }})},
+	// {"console-headers-replaceattr", NewHandler(io.Discard, &HandlerOptions{Headers: []string{"foo"}, Level: slog.LevelDebug, AddSource: false, ReplaceAttr: func(_ []string, a slog.Attr) slog.Attr { return a }})},
 	{"std-text", slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false})},
 	// {"std-text-replaceattr", slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false, ReplaceAttr: func(_ []string, a slog.Attr) slog.Attr { return a }})},
 	{"std-json", slog.NewJSONHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false})},

--- a/bench_test.go
+++ b/bench_test.go
@@ -36,6 +36,7 @@ var attrs = []slog.Attr{
 	slog.Any("err", errors.New("yo")),
 	slog.Group("empty"),
 	slog.Group("group", slog.String("bar", "baz")),
+	slog.String("multi", "foo\nbar"),
 }
 
 var attrsAny = func() (a []any) {

--- a/buffer.go
+++ b/buffer.go
@@ -30,6 +30,10 @@ func (b *buffer) Cap() int {
 }
 
 func (b *buffer) WriteTo(dst io.Writer) (int64, error) {
+	if b == nil {
+		// for convenience, if receiver is nil, treat it like an empty buffer
+		return 0, nil
+	}
 	l := len(*b)
 	if l == 0 {
 		return 0, nil

--- a/buffer.go
+++ b/buffer.go
@@ -46,6 +46,12 @@ func (b *buffer) WriteTo(dst io.Writer) (int64, error) {
 }
 
 func (b *buffer) Reset() {
+	// To reduce peak allocation, return only smaller buffers to the pool.
+	const maxBufferSize = 16 << 10
+	if cap(*b) > maxBufferSize {
+		*b = (*b)[:0:maxBufferSize]
+		return
+	}
 	*b = (*b)[:0]
 }
 

--- a/buffer.go
+++ b/buffer.go
@@ -45,6 +45,11 @@ func (b *buffer) WriteTo(dst io.Writer) (int64, error) {
 	return int64(n), nil
 }
 
+func (b *buffer) Write(bt []byte) (int, error) {
+	*b = append(*b, bt...)
+	return len(bt), nil
+}
+
 func (b *buffer) Reset() {
 	*b = (*b)[:0]
 }

--- a/buffer_test.go
+++ b/buffer_test.go
@@ -46,6 +46,15 @@ func TestBuffer_WriteTo(t *testing.T) {
 	AssertNoError(t, err)
 	AssertEqual(t, "foobar", dest.String())
 	AssertZero(t, b.Len())
+
+	t.Run("nilbuffer", func(t *testing.T) {
+		// if receiver is nil, do nothing
+		dest.Reset()
+		c, err := (*buffer)(nil).WriteTo(&dest)
+		AssertNoError(t, err)
+		AssertZero(t, c)
+		AssertZero(t, dest.Len())
+	})
 }
 
 func TestBuffer_Clone(t *testing.T) {

--- a/encoding.go
+++ b/encoding.go
@@ -15,6 +15,7 @@ var encoderPool = &sync.Pool{
 		e.groups = make([]string, 0, 10)
 		e.buf = make(buffer, 0, 1024)
 		e.trailerBuf = make(buffer, 0, 1024)
+		e.headers = make([]slog.Attr, 0, 6)
 		return e
 	},
 }
@@ -23,6 +24,7 @@ type encoder struct {
 	h               *Handler
 	buf, trailerBuf buffer
 	groups          []string
+	headers         []slog.Attr
 }
 
 func newEncoder(h *Handler) *encoder {
@@ -228,9 +230,6 @@ func (e encoder) writeHeaders(buf *buffer, headers []slog.Attr) bool {
 			a = e.h.opts.ReplaceAttr(nil, a)
 			a.Value = a.Value.Resolve()
 		}
-		// todo: this skips empty values, omitting them entire from the header.
-		// alternately, I could print <null> or something, so the number of
-		// headers in each log entry is always fixed...
 		if a.Value.Equal(slog.Value{}) {
 			continue
 		}

--- a/encoding.go
+++ b/encoding.go
@@ -144,9 +144,13 @@ func (e encoder) writeValue(buf *buffer, value slog.Value) {
 	case slog.KindAny:
 		switch v := value.Any().(type) {
 		case error:
-			e.withColor(buf, e.opts.Theme.AttrValueError(), func() {
-				fmt.Fprintf(buf, "%+v", v)
-			})
+			if _, ok := v.(fmt.Formatter); ok {
+				e.withColor(buf, e.opts.Theme.AttrValueError(), func() {
+					fmt.Fprintf(buf, "%+v", v)
+				})
+			} else {
+				e.writeColoredString(buf, v.Error(), e.opts.Theme.AttrValueError())
+			}
 			return
 		case fmt.Stringer:
 			e.writeColoredString(buf, v.String(), attrValue)

--- a/encoding.go
+++ b/encoding.go
@@ -144,7 +144,9 @@ func (e encoder) writeValue(buf *buffer, value slog.Value) {
 	case slog.KindAny:
 		switch v := value.Any().(type) {
 		case error:
-			e.writeColoredString(buf, v.Error(), e.opts.Theme.AttrValueError())
+			e.withColor(buf, e.opts.Theme.AttrValueError(), func() {
+				fmt.Fprintf(buf, "%+v", v)
+			})
 			return
 		case fmt.Stringer:
 			e.writeColoredString(buf, v.String(), attrValue)

--- a/encoding.go
+++ b/encoding.go
@@ -114,6 +114,7 @@ func (e encoder) writeAttr(buf *buffer, a slog.Attr, group string) {
 		}
 		return
 	}
+
 	buf.AppendByte(' ')
 	e.withColor(buf, e.opts.Theme.AttrKey(), func() {
 		if group != "" {

--- a/handler.go
+++ b/handler.go
@@ -18,6 +18,7 @@ var cwd, _ = os.Getwd()
 
 // HandlerOptions are options for a ConsoleHandler.
 // A zero HandlerOptions consists entirely of default values.
+// ReplaceAttr works identically to [slog.HandlerOptions.ReplaceAttr]
 type HandlerOptions struct {
 	// AddSource causes the handler to compute the source code position
 	// of the log statement and add a SourceKey attribute to the output.
@@ -38,6 +39,10 @@ type HandlerOptions struct {
 
 	// Theme defines the colorized output using ANSI escape sequences
 	Theme Theme
+
+	// ReplaceAttr is called to rewrite each non-group attribute before it is logged.
+	// See [slog.HandlerOptions]
+	ReplaceAttr func(groups []string, a slog.Attr) slog.Attr
 }
 
 type Handler struct {
@@ -86,7 +91,7 @@ func (h *Handler) Handle(_ context.Context, rec slog.Record) error {
 
 	h.enc.writeTimestamp(buf, rec.Time)
 	h.enc.writeLevel(buf, rec.Level)
-	if h.opts.AddSource && rec.PC > 0 {
+	if h.opts.AddSource {
 		h.enc.writeSource(buf, rec.PC, cwd)
 	}
 	h.enc.writeMessage(buf, rec.Level, rec.Message)

--- a/handler.go
+++ b/handler.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"slices"
 	"strings"
 	"time"
 )
@@ -35,6 +36,11 @@ type HandlerOptions struct {
 	// Theme defines the colorized output using ANSI escape sequences
 	Theme Theme
 
+	// Headers are a list of attribute keys.  These attributes will be removed from
+	// the trailing attr list, and the values will be inserted between
+	// the level/source and the message, in the configured order.
+	Headers []string
+
 	// ReplaceAttr is called to rewrite each non-group attribute before it is logged.
 	// See [slog.HandlerOptions]
 	ReplaceAttr func(groups []string, a slog.Attr) slog.Attr
@@ -46,6 +52,7 @@ type Handler struct {
 	groupPrefix string
 	groups      []string
 	context     buffer
+	headers     []slog.Attr
 }
 
 var _ slog.Handler = (*Handler)(nil)
@@ -71,6 +78,7 @@ func NewHandler(out io.Writer, opts *HandlerOptions) *Handler {
 		out:         out,
 		groupPrefix: "",
 		context:     nil,
+		headers:     make([]slog.Attr, len(opts.Headers)),
 	}
 }
 
@@ -82,30 +90,66 @@ func (h *Handler) Enabled(_ context.Context, l slog.Level) bool {
 // Handle implements slog.Handler.
 func (h *Handler) Handle(_ context.Context, rec slog.Record) error {
 	enc := newEncoder(h)
-	buf := &enc.buf
+	headerBuf := &enc.buf
+	trailerBuf := &enc.trailerBuf
 
-	enc.writeTimestamp(buf, rec.Time)
-	enc.writeLevel(buf, rec.Level)
+	enc.writeTimestamp(headerBuf, rec.Time)
+	enc.writeLevel(headerBuf, rec.Level)
+
+	var writeHeaderSeparator bool
 	if h.opts.AddSource {
-		enc.writeSource(buf, rec.PC, cwd)
+		writeHeaderSeparator = enc.writeSource(headerBuf, rec.PC, cwd)
 	}
-	enc.writeMessage(buf, rec.Level, rec.Message)
-	buf.copy(&h.context)
+
+	enc.writeMessage(trailerBuf, rec.Level, rec.Message)
+
+	trailerBuf.copy(&h.context)
+
+	headers := h.headers
+	headersChanged := false
 	rec.Attrs(func(a slog.Attr) bool {
-		enc.writeAttr(buf, a, h.groupPrefix)
+		idx := slices.IndexFunc(h.opts.Headers, func(s string) bool { return s == a.Key })
+		if idx >= 0 {
+			if !headersChanged {
+				headersChanged = true
+				// todo: I think should could be replace now by a preallocated slice in encoder, avoiding allocation
+				// todo: this makes one allocation, but only if the headers weren't already
+				// satisfied by prior WithAttrs().  Could use a pool of *[]slog.Value, but
+				// I'm not sure it's worth it.
+				headers = make([]slog.Attr, len(h.opts.Headers))
+				copy(headers, h.headers)
+			}
+			headers[idx] = a
+			return true
+		}
+		enc.writeAttr(trailerBuf, a, h.groupPrefix)
 		return true
 	})
-	enc.NewLine(buf)
-	if _, err := buf.WriteTo(h.out); err != nil {
-		return err
+	enc.NewLine(trailerBuf)
+
+	if len(headers) > 0 {
+		if enc.writeHeaders(headerBuf, headers) {
+			writeHeaderSeparator = true
+		}
 	}
 
+	if writeHeaderSeparator {
+		enc.writeHeaderSeparator(headerBuf)
+	}
+
+	if _, err := headerBuf.WriteTo(h.out); err != nil {
+		return err
+	}
+	if _, err := trailerBuf.WriteTo(h.out); err != nil {
+		return err
+	}
 	enc.free()
 	return nil
 }
 
 // WithAttrs implements slog.Handler.
 func (h *Handler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	headers := h.extractHeaders(attrs)
 	newCtx := h.context
 	enc := newEncoder(h)
 	for _, a := range attrs {
@@ -118,6 +162,7 @@ func (h *Handler) WithAttrs(attrs []slog.Attr) slog.Handler {
 		groupPrefix: h.groupPrefix,
 		context:     newCtx,
 		groups:      h.groups,
+		headers:     headers,
 	}
 }
 
@@ -134,5 +179,28 @@ func (h *Handler) WithGroup(name string) slog.Handler {
 		groupPrefix: groupPrefix,
 		context:     h.context,
 		groups:      append(h.groups, name),
+		headers:     h.headers,
 	}
+}
+
+// extractHeaders scans the attributes for keys specified in Headers.
+// If found, their values are saved in a new list.
+// The original attribute list will be modified to remove the extracted attributes.
+func (h *Handler) extractHeaders(attrs []slog.Attr) (headers []slog.Attr) {
+	changed := false
+	headers = h.headers
+	for i, attr := range attrs {
+		idx := slices.IndexFunc(h.opts.Headers, func(s string) bool { return s == attr.Key })
+		if idx >= 0 {
+			if !changed {
+				// make a copy of prefixes:
+				headers = make([]slog.Attr, len(h.headers))
+				copy(headers, h.headers)
+			}
+			headers[idx] = attr
+			attrs[i] = slog.Attr{} // remove the prefix attribute
+			changed = true
+		}
+	}
+	return
 }

--- a/handler_test.go
+++ b/handler_test.go
@@ -106,6 +106,73 @@ func TestHandler_Attr(t *testing.T) {
 	AssertEqual(t, expected, buf.String())
 }
 
+func TestHandler_AttrsWithNewlines(t *testing.T) {
+	tests := []struct {
+		name           string
+		msg            string
+		escapeNewlines bool
+		attrs          []slog.Attr
+		want           string
+	}{
+		{
+			name: "single attr",
+			attrs: []slog.Attr{
+				slog.String("foo", "line one\nline two"),
+			},
+			want: "INF multiline attrs foo=\nline one\nline two\n",
+		},
+		{
+			name: "multiple attrs",
+			attrs: []slog.Attr{
+				slog.String("foo", "line one\nline two"),
+				slog.String("bar", "line three\nline four"),
+			},
+			want: "INF multiline attrs foo=\nline one\nline two\nbar=\nline three\nline four\n",
+		},
+		{
+			name: "sort multiline attrs to end",
+			attrs: []slog.Attr{
+				slog.String("size", "big"),
+				slog.String("foo", "line one\nline two"),
+				slog.String("weight", "heavy"),
+				slog.String("bar", "line three\nline four"),
+				slog.String("color", "red"),
+			},
+			want: "INF multiline attrs size=big weight=heavy color=red foo=\nline one\nline two\nbar=\nline three\nline four\n",
+		},
+		{
+			name: "multiline message",
+			msg:  "multiline\nmessage",
+			want: "INF multiline\nmessage\n",
+		},
+		{
+			name: "preserve leading and trailing newlines",
+			attrs: []slog.Attr{
+				slog.String("foo", "\nline one\nline two\n"),
+			},
+			want: "INF multiline attrs foo=\n\nline one\nline two\n\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			buf := bytes.Buffer{}
+			h := NewHandler(&buf, &HandlerOptions{NoColor: true})
+
+			msg := test.msg
+			if msg == "" {
+				msg = "multiline attrs"
+			}
+			rec := slog.NewRecord(time.Time{}, slog.LevelInfo, msg, 0)
+			rec.AddAttrs(test.attrs...)
+			AssertNoError(t, h.Handle(context.Background(), rec))
+
+			AssertEqual(t, test.want, buf.String())
+		})
+
+	}
+}
+
 // Handlers should not log groups (or subgroups) without fields.
 // '- If a group has no Attrs (even if it has a non-empty key), ignore it.'
 // https://pkg.go.dev/log/slog@master#Handler

--- a/handler_test.go
+++ b/handler_test.go
@@ -282,6 +282,7 @@ func TestThemes(t *testing.T) {
 	for _, theme := range []Theme{
 		NewDefaultTheme(),
 		NewBrightTheme(),
+		NewDimTheme(),
 	} {
 		t.Run(theme.Name(), func(t *testing.T) {
 			level := slog.LevelInfo
@@ -292,6 +293,7 @@ func TestThemes(t *testing.T) {
 			timeFormat := time.Kitchen
 			index := -1
 			toIndex := -1
+			var lastField []byte
 			h := NewHandler(&buf, &HandlerOptions{
 				AddSource:  true,
 				TimeFormat: timeFormat,
@@ -309,6 +311,7 @@ func TestThemes(t *testing.T) {
 					bufBytes = bufBytes[toIndex:]
 					index = bytes.IndexByte(bufBytes, '\x1b')
 					AssertNotEqual(t, -1, index)
+					lastField = bufBytes[:index]
 					toIndex = index + len(ResetMod)
 					AssertEqual(t, ResetMod, ANSIMod(bufBytes[index:toIndex]))
 					bufBytes = bufBytes[toIndex:]
@@ -352,9 +355,16 @@ func TestThemes(t *testing.T) {
 							checkANSIMod(t, "AttrKey", theme.AttrKey())
 						}
 
-						// AttrValue
-						if theme.AttrValue() != "" {
-							checkANSIMod(t, "AttrValue", theme.AttrValue())
+						if string(lastField) == "error=" {
+							// AttrValueError
+							if theme.AttrValueError() != "" {
+								checkANSIMod(t, "AttrValueError", theme.AttrValueError())
+							}
+						} else {
+							// AttrValue
+							if theme.AttrValue() != "" {
+								checkANSIMod(t, "AttrValue", theme.AttrValue())
+							}
 						}
 					}
 				})

--- a/handler_test.go
+++ b/handler_test.go
@@ -292,6 +292,7 @@ type valuer struct {
 func (v valuer) LogValue() slog.Value {
 	return v.v
 }
+
 func TestHandler_ReplaceAttr(t *testing.T) {
 	pc, file, line, _ := runtime.Caller(0)
 	cwd, _ := os.Getwd()
@@ -498,6 +499,9 @@ func TestHandler_ReplaceAttr(t *testing.T) {
 			replaceAttr: replaceAttrWith("size", slog.Group("l1", slog.String("flavor", "vanilla"))),
 			want:        "2010-05-06 07:08:09 INF " + sourceField + " > foobar l1.flavor=vanilla color=red\n",
 		},
+		// {
+		// 	name: "replace header",
+		// }
 	}
 
 	for _, test := range tests {
@@ -531,6 +535,155 @@ func TestHandler_ReplaceAttr(t *testing.T) {
 		})
 	}
 
+}
+
+func TestHandler_Headers(t *testing.T) {
+	pc, file, line, _ := runtime.Caller(0)
+	cwd, _ := os.Getwd()
+	file, _ = filepath.Rel(cwd, file)
+	sourceField := fmt.Sprintf("%s:%d", file, line)
+
+	tests := []struct {
+		name       string
+		opts       HandlerOptions
+		attrs      []slog.Attr
+		withAttrs  []slog.Attr
+		withGroups []string
+		want       string
+	}{
+		{
+			name:  "no headers",
+			attrs: []slog.Attr{slog.String("foo", "bar")},
+			want:  "INF with headers foo=bar\n",
+		},
+		{
+			name: "one header",
+			opts: HandlerOptions{Headers: []string{"foo"}},
+			attrs: []slog.Attr{
+				slog.String("foo", "bar"),
+				slog.String("bar", "baz"),
+			},
+			want: "INF bar > with headers bar=baz\n",
+		},
+		{
+			name: "two headers",
+			opts: HandlerOptions{Headers: []string{"foo", "bar"}},
+			attrs: []slog.Attr{
+				slog.String("foo", "bar"),
+				slog.String("bar", "baz"),
+			},
+			want: "INF bar baz > with headers\n",
+		},
+		{
+			name:  "missing headers",
+			opts:  HandlerOptions{Headers: []string{"foo", "bar"}},
+			attrs: []slog.Attr{slog.String("bar", "baz"), slog.String("baz", "foo")},
+			want:  "INF baz > with headers baz=foo\n",
+		},
+		{
+			name: "missing all headers",
+			opts: HandlerOptions{Headers: []string{"foo", "bar"}},
+			want: "INF with headers\n",
+		},
+		{
+			name: "header and source",
+			opts: HandlerOptions{Headers: []string{"foo"}, AddSource: true},
+			attrs: []slog.Attr{
+				slog.String("foo", "bar"),
+				slog.String("bar", "baz"),
+			},
+			want: "INF " + sourceField + " bar > with headers bar=baz\n",
+		},
+		{
+			name: "withattrs",
+			opts: HandlerOptions{Headers: []string{"foo"}},
+			attrs: []slog.Attr{
+
+				slog.String("bar", "baz"),
+			},
+			withAttrs: []slog.Attr{
+				slog.String("foo", "bar"),
+			},
+			want: "INF bar > with headers bar=baz\n",
+		},
+		{
+			name: "withgroup",
+			opts: HandlerOptions{Headers: []string{"foo", "bar"}},
+			attrs: []slog.Attr{
+				slog.String("bar", "baz"),
+				slog.String("baz", "foo"),
+			},
+			withGroups: []string{"group"},
+			withAttrs: []slog.Attr{
+				slog.String("foo", "bar"),
+			},
+			want: "INF bar baz > with headers group.baz=foo\n",
+		},
+		// {
+		// 	name: "resolver header",
+		// }
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			buf := bytes.Buffer{}
+
+			opts := &test.opts
+			opts.NoColor = true
+			var h slog.Handler = NewHandler(&buf, &test.opts)
+			if test.withAttrs != nil {
+				h = h.WithAttrs(test.withAttrs)
+			}
+			for _, g := range test.withGroups {
+				h = h.WithGroup(g)
+			}
+
+			rec := slog.NewRecord(time.Time{}, slog.LevelInfo, "with headers", pc)
+
+			rec.AddAttrs(test.attrs...)
+
+			AssertNoError(t, h.Handle(context.Background(), rec))
+			AssertEqual(t, test.want, buf.String())
+		})
+	}
+
+	t.Run("withAttrs state keeping", func(t *testing.T) {
+		// test to make sure the way that WithAttrs() copies the cached headers doesn't leak
+		// headers back to the parent handler or to subsequent Handle() calls (i.e. ensure that
+		// the headers slice is copied at the right times).
+
+		buf := bytes.Buffer{}
+		h := NewHandler(&buf, &HandlerOptions{
+			Headers:    []string{"foo", "bar"},
+			TimeFormat: "0",
+			NoColor:    true,
+		})
+
+		assertLog := func(t *testing.T, handler slog.Handler, want string, attrs ...slog.Attr) {
+			buf.Reset()
+			rec := slog.NewRecord(time.Time{}, slog.LevelInfo, "with headers", pc)
+
+			rec.AddAttrs(attrs...)
+
+			AssertNoError(t, handler.Handle(context.Background(), rec))
+			AssertEqual(t, want, buf.String())
+		}
+
+		assertLog(t, h, "INF bar > with headers\n", slog.String("foo", "bar"))
+
+		h2 := h.WithAttrs([]slog.Attr{slog.String("foo", "baz")})
+		assertLog(t, h2, "INF baz > with headers\n")
+
+		h3 := h2.WithAttrs([]slog.Attr{slog.String("foo", "buz")})
+		assertLog(t, h3, "INF buz > with headers\n")
+		// creating h3 should not have affected h2
+		assertLog(t, h2, "INF baz > with headers\n")
+
+		// overriding attrs shouldn't affect the handler
+		assertLog(t, h2, "INF biz > with headers\n", slog.String("foo", "biz"))
+		assertLog(t, h2, "INF baz > with headers\n")
+
+	})
 }
 
 func TestHandler_Err(t *testing.T) {

--- a/handler_test.go
+++ b/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -72,6 +73,17 @@ func (v *theValuer) LogValue() slog.Value {
 	return slog.StringValue(fmt.Sprintf("The word is '%s'", v.word))
 }
 
+type formatterError struct {
+	error
+}
+
+func (e *formatterError) Format(f fmt.State, verb rune) {
+	if verb == 'v' && f.Flag('+') {
+		io.WriteString(f, "formatted ")
+	}
+	io.WriteString(f, e.Error())
+}
+
 func TestHandler_Attr(t *testing.T) {
 	buf := bytes.Buffer{}
 	h := NewHandler(&buf, &HandlerOptions{NoColor: true})
@@ -87,6 +99,7 @@ func TestHandler_Attr(t *testing.T) {
 		slog.Duration("dur", time.Second),
 		slog.Group("group", slog.String("foo", "bar"), slog.Group("subgroup", slog.String("foo", "bar"))),
 		slog.Any("err", errors.New("the error")),
+		slog.Any("formattedError", &formatterError{errors.New("the error")}),
 		slog.Any("stringer", theStringer{}),
 		slog.Any("nostringer", noStringer{Foo: "bar"}),
 		// Resolve LogValuer items in addition to Stringer items.
@@ -102,7 +115,7 @@ func TestHandler_Attr(t *testing.T) {
 	)
 	AssertNoError(t, h.Handle(context.Background(), rec))
 
-	expected := fmt.Sprintf("%s INF foobar bool=true int=-12 uint=12 float=3.14 foo=bar time=%s dur=1s group.foo=bar group.subgroup.foo=bar err=the error stringer=stringer nostringer={bar} valuer=The word is 'distant'\n", now.Format(time.DateTime), now.Format(time.DateTime))
+	expected := fmt.Sprintf("%s INF foobar bool=true int=-12 uint=12 float=3.14 foo=bar time=%s dur=1s group.foo=bar group.subgroup.foo=bar err=the error formattedError=formatted the error stringer=stringer nostringer={bar} valuer=The word is 'distant'\n", now.Format(time.DateTime), now.Format(time.DateTime))
 	AssertEqual(t, expected, buf.String())
 }
 

--- a/theme.go
+++ b/theme.go
@@ -157,7 +157,7 @@ func NewDimTheme() Theme {
 		source:         ToANSICode(Bold, BrightBlack),
 		message:        ToANSICode(Bold),
 		messageDebug:   ToANSICode(),
-		attrKey:        ToANSICode(Blue),
+		attrKey:        ToANSICode(Cyan),
 		attrValue:      ToANSICode(Gray),
 		attrValueError: ToANSICode(Bold, Red),
 		levelError:     ToANSICode(Red),

--- a/theme.go
+++ b/theme.go
@@ -149,3 +149,20 @@ func NewBrightTheme() Theme {
 		levelDebug:     ToANSICode(),
 	}
 }
+
+func NewDimTheme() Theme {
+	return ThemeDef{
+		name:           "Dim",
+		timestamp:      ToANSICode(BrightBlack),
+		source:         ToANSICode(Bold, BrightBlack),
+		message:        ToANSICode(Bold),
+		messageDebug:   ToANSICode(),
+		attrKey:        ToANSICode(Blue),
+		attrValue:      ToANSICode(Gray),
+		attrValueError: ToANSICode(Bold, Red),
+		levelError:     ToANSICode(Red),
+		levelWarn:      ToANSICode(Yellow),
+		levelInfo:      ToANSICode(Green),
+		levelDebug:     ToANSICode(),
+	}
+}


### PR DESCRIPTION
This PR combines the other PRs:
- Headers: Configurable list of attrs which are moved into the header section of the log line, between the source and message fields #6 
- ReplaceAttr support: Just like slog.HandlerOptions.ReplaceAttr.  Will work with all the builtin attrs and with headers as well. #5 
- Attr values with newlines: moves any attributes with newlines in their values to the end of the log line.  Makes it easier to scan log output when newlines are mixed in with other attribute values. #8 
- Error formatting: if `error` attr values also implement `fmt.Formatter`, then print the error using fmt.Printf("%+v").  Several error packages use this convention for printing stack traces. #7 
- New "Dim" theme, but with cyan attrs keys.  The "Dim" theme in #10 changes two things from the Default theme: the attr key color goes from Cyan to Blue, and the attr value goes from default to Gray.  I tested that on several terminals, using common themes.  The Blue doesn't work well with some common themes.  It's two dark and vivid.  So the Dim theme in this PR only changes the attr value color to Gray.  It's such a subtle change that maybe you'd consider just changing the Default theme? #9 

I've benchmarked this against the main branch.  Even when the features are used, there are still zero allocations.  The only feature which introduces some performance overhead is the multiline value handling, which increased processing by about 75ns on my system (from about 825ns to 900ns).  The other features have no impact when not used.

As an example, given this:
```go
h := console.NewHandler(os.Stdout, &console.HandlerOptions{
				AddSource:  true,
				Theme:      console.NewDimTheme(),
				Headers:    []string{"logger"},
				TimeFormat: time.Kitchen,
				ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
					if a.Key == "size"  && a.Value.Int64() > 100 {
						a.Value = slog.StringValue("huge")
					}
					return a
				},
			})

slog.New(v.handler).With("logger", "main").Info("hello world", "err", merry.New("boom"), "color", "red", "err2", merry.New("bang"), "size", 101)
```

Output looks like:
![image](https://github.com/user-attachments/assets/cdf3eada-9958-4464-ada5-1536a69ec8ef)

Here's another sample, from macos Terminal.app, Basic Theme:
![image](https://github.com/user-attachments/assets/3db53905-3fcd-4536-8234-25dd62d9ea28)

Note:
- The "Dim" theme: Exactly the same is the "Default" theme, except attr values are Gray instead of default color
- The "logger" attr has been extracted and placed in the header section, after the source.  
-  ReplaceAttr was used to replace the value of the "size" attr: 101 -> "huge"
- The error value was pretty printed with a full stacktrace
- Both of the multiline values were moved to the end of the log line

More work could be considered on multiline values, like placing the entire value on its own lines.  Still playing with different options.